### PR TITLE
Fix from previous PR. Pass file contents to Buffer.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/index.js
+++ b/index.js
@@ -1,22 +1,39 @@
 /* jshint node: true */
 'use strict';
 
-var es = require('event-stream');
+var through = require('through2');
 var gutil = require('gulp-util');
 var extend = require('lodash.assign');
 
 var headerPlugin = function(headerText, data) {
-  headerText = headerText || '';
-  return es.map(function(file, cb){
-    file.pipe(es.wait(function(err, contents){
-      if (err) return cb(err);
-      file.contents = Buffer.concat([
-        new Buffer(gutil.template(headerText, extend({file : file}, data))),
-        contents
-      ]);
-      cb(null, file);
-    }));
-  });
+    headerText = headerText || '';
+
+    var stream = through.obj(function(file, enc, cb) {
+
+        var template = gutil.template(headerText, extend({file : file}, data));
+
+        if (file.isBuffer()) {
+            file.contents = Buffer.concat([
+                new Buffer(template),
+                file.contents
+            ]);
+        }
+
+        if (file.isStream()) {
+            var stream = through();
+            stream.write(new Buffer(template));
+            stream.on('error', this.emit.bind(this, 'error'));
+            file.contents = file.contents.pipe(stream);
+        }
+
+        // make sure the file goes through the next gulp plugin
+        this.push(file);
+        // tell the stream engine that we are done with this file
+        cb();
+    });
+
+    // returning the file stream
+    return stream;
 };
 
 module.exports = headerPlugin;

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
   "dependencies": {
     "event-stream": "*",
     "gulp-util": "*",
-    "lodash.assign": "*"
+    "lodash.assign": "*",
+    "through2": "*"
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "vinyl": "*"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -7,13 +7,15 @@ var should = require('should');
 var gutil = require('gulp-util');
 var fs = require('fs');
 var path = require('path');
+var es = require('event-stream');
+var File = require('vinyl');
 require('mocha');
 
 describe('gulp-header', function() {
   var fakeFile;
 
   function getFakeFile(fileContent){
-    return new gutil.File({
+    return new File({
       path: './test/fixture/file.js',
       cwd: './test/',
       base: './test/fixture/',
@@ -22,11 +24,8 @@ describe('gulp-header', function() {
   }
 
   function getFakeFileReadStream(){
-    return new gutil.File({
-      path: './test/fixture/file.js',
-      cwd: './test/',
-      base: './test/fixture/',
-      contents: fs.createReadStream(path.join(__dirname, './fixture/file.js'))
+    return new File({
+      contents: es.readArray(['Hello world'])
     });
   }
 
@@ -46,7 +45,7 @@ describe('gulp-header', function() {
         should.exist(newFile.contents);
         newFile.path.should.equal('./test/fixture/file.js');
         newFile.relative.should.equal('file.js');
-        newFile.contents.toString().should.equal('Hello world');
+        newFile.contents.toString('utf8').should.equal('Hello world');
         ++file_count;
       });
 
@@ -59,30 +58,33 @@ describe('gulp-header', function() {
       stream.end();
     });
 
-
     it('should prepend the header to the file content', function(done) {
-      var stream = header('And then i said : ');
-      stream.on('data', function (newFile) {
-        should.exist(newFile.contents);
-        newFile.contents.toString().should.equal('And then i said : Hello world');
-      });
-      stream.once('end', done);
+      var myHeader = header('And then i said : ');
 
-      stream.write(fakeFile);
-      stream.end();
+      myHeader.write(fakeFile);
+
+      myHeader.once('data', function(file) {
+        should(file.isBuffer()).ok;
+        should.exist(file.contents);
+        file.contents.toString('utf8').should.equal('And then i said : Hello world');
+        done();
+      });
+
     });
 
-
     it('should prepend the header to the file content (stream)', function(done) {
-      var stream = header('And then i said : ');
-      stream.on('data', function (newFile) {
-        should.exist(newFile.contents);
-        newFile.contents.toString().should.equal('And then i said : Hello world');
-      });
-      stream.once('end', done);
+      var myHeader = header('And then i said : ');
 
-      stream.write(getFakeFileReadStream());
-      stream.end();
+      myHeader.write(getFakeFileReadStream());
+
+      myHeader.once('data', function(file) {
+        should(file.isStream()).ok;
+        file.contents.pipe(es.wait(function(err, data) {
+          data.toString('utf8').should.equal('And then i said : Hello world');
+          done();
+        }));
+      });
+
     });
 
     it('should format the header', function(done) {
@@ -90,7 +92,7 @@ describe('gulp-header', function() {
       //var stream = header('And then ${foo} said : ', { foo : 'you' } );
       stream.on('data', function (newFile) {
         should.exist(newFile.contents);
-        newFile.contents.toString().should.equal('And then you said : Hello world');
+        newFile.contents.toString('utf8').should.equal('And then you said : Hello world');
       });
       stream.once('end', done);
 
@@ -103,7 +105,7 @@ describe('gulp-header', function() {
       var stream = header('And then ${foo} said : ', { foo : 'you' } );
       stream.on('data', function (newFile) {
         should.exist(newFile.contents);
-        newFile.contents.toString().should.equal('And then you said : Hello world');
+        newFile.contents.toString('utf8').should.equal('And then you said : Hello world');
       });
       stream.once('end', done);
 
@@ -119,7 +121,7 @@ describe('gulp-header', function() {
         ''].join('\n'));
       stream.on('data', function (newFile) {
         should.exist(newFile.contents);
-        newFile.contents.toString().should.equal('file.js\n./test/fixture/file.js\nHello world');
+        newFile.contents.toString('utf8').should.equal('file.js\n./test/fixture/file.js\nHello world');
       });
       stream.once('end', done);
 


### PR DESCRIPTION
PR (https://github.com/tracker1/gulp-header/pull/3) has broken the current node version's ability to process Buffers.  My specific use case of gulp-headers is as a transitive dependency of the gulp-angular-templatecache plugin.  This PR should fix the issue by conditionally doing work based on input being a stream vs buffer.  The code is pretty much taken verbatim from Gulp's plugin documentation found here:
https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/README.md

The following is a trace of the error produced in current version of gulp-header:
It fails because gulp-header passes a Stream to Buffer.concat.

```
      file.contents = Buffer.concat([
        new Buffer(gutil.template(headerText, extend({file : file}, data))),
        contents // This is not always a Buffer and should be.
      ]);
```

Stacktrace

```
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
TypeError: Object $templateCache.put("components/server-errors/server-errors.html","<div><div ng-if=\"hasErrors()\" class=\"message message-error slide-animation\"><strong>Please correct the following errors:</strong><ul><li ng-repeat=\"error in errors.fieldErrors\">{{error.message}}</li><li ng-repeat=\"error in errors.objectErrors\">{{error.message}}</li></ul></div></div>"); has no method 'copy'
    at Function.Buffer.concat (buffer.js:499:9)
    at /Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/gulp-angular-templatecache/node_modules/gulp-header/index.js:13:30
    at Stream.<anonymous> (/Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/event-stream/index.js:298:20)
    at _end (/Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/event-stream/node_modules/through/index.js:65:9)
    at Stream.stream.end (/Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/event-stream/node_modules/through/index.js:74:5)
    at File.pipe (/Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/gulp-util/node_modules/vinyl/index.js:67:14)
    at /Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/gulp-angular-templatecache/node_modules/gulp-header/index.js:11:10
    at wrappedMapper (/Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/event-stream/node_modules/map-stream/index.js:84:19)
    at Stream.stream.write (/Users/jblaisdell/Git/bloomhealth/webapps/nexus/node_modules/event-stream/node_modules/map-stream/index.js:96:21)
    at Stream.ondata (stream.js:51:26)
```
