### PR TITLE
Removing lodash.template dependency as per the component Governance Alert

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const Concat = require('concat-with-sourcemaps');
 const through = require('through2');
-const lodashTemplate = require('lodash.template');
+const _ = require('lodash');
 const stream = require('stream');
 const path = require('path');
 
@@ -21,7 +21,7 @@ module.exports = (headerText, data) => {
     const template =
       data === false
         ? headerText
-        : lodashTemplate(headerText)(
+        : _.template(headerText)(
             Object.assign({}, file.data || {}, { file: file, filename: filename }, data)
           );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5356,36 +5356,14 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
-    },
-    "lodash._reinterpolate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
-    },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.templatesettings": "^4.0.0"
-      }
-    },
-    "lodash.templatesettings": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
-      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "requires": {
-        "lodash._reinterpolate": "^3.0.0"
-      }
     },
     "lolex": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "concat-with-sourcemaps": "^1.1.0",
     "jest": "^25.1.0",
-    "lodash.template": "^4.5.0",
+    "lodash": "^4.17.21",
     "map-stream": "0.0.7",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
As per the component governance alert made changes to remove lodash.template and replace with lodash. Made the fix as per the  suggestion provided in below link.

https://github.com/lodash/lodash/issues/5851

_"If you are using lodash.template directly in a project, to remove this alert you should install the latest version of lodash and use the template method off the main Lodash module instead, if you can't use another approach entirely."_